### PR TITLE
Subir las minutas, y la estructura de las metas 2021

### DIFF
--- a/Consejo_2021/Metas.md
+++ b/Consejo_2021/Metas.md
@@ -1,0 +1,17 @@
+# Metas del Consejo Directivo para 2021
+
+Las siguientes, son las metas definidas por el consejo directo, tras una consulta con el Core Team
+para establecer un rumbo definido de los esfuerzos y recursos de la comunidad. Son enunciativas,
+más no limitativas, pues durante el transcurso del año se pueden agregar nuevas metas o modificar
+las actuales; buscando siempre la mejor convivencia dentro de la comunidad, crecimiento de la misma
+y cabal cumplimiento de los proyectos que se definan.
+
+## Metas para Meetup
+
+## Metas para Redes Sociales
+
+## Metas para Repositorio de GitHub
+
+## Metas para Financiamiento
+
+## Metas para Proyectos

--- a/Consejo_2021/Minutas/2020-12-28.md
+++ b/Consejo_2021/Minutas/2020-12-28.md
@@ -1,0 +1,43 @@
+# Junta de Consejo Directivo
+
+28 DE DICIEMBRE DE 2020 / 20:00 HRS  / Google Meet
+
+## Asistentes 
+
+Dafne, Gaby, David Flores, David León, Mariano Renteria
+
+## Agenda
+
+**Propuestas de las acciones del consejo directivo**
+* Hacer visible las reuniones del consejo, lo más posible.
+* Crear minutas de cada reunión para después poder comentar con la comunidad.
+* El objetivo principal del consejo es dirigir o definir el rumbo de los recursos de la comunidad.
+* Organizar cada miembro del consejo como seguidor de los grupos del Core Team.
+* Leer el documento del Governance
+
+## Notas
+
+* **Buscar iniciativas** dentro de la comunidad, parecido a como lo hacen en otras comunidades, como crear clubs de lectura de libros, organizar hackatones.  
+* Queremos dar difusión a las **actividades que hacen algunos miembros de la comunidad**, conferencias, pláticas u otras tareas que comparten en las redes sociales.
+* Buscar las **cuentas sociales oficiales** de ciertos temas: Symfony, PHP, Laravel, etc. y también dar difusión de estas notas relevantes a través de las redes sociales.
+* El **meetup es el proyecto principal** de la comunidad, alrededor del cual se crea y genera la interacción de los miembros, y a dónde se encaminan los esfuerzos.
+* Es necesario buscar con cada grupo del Core Team, **métricas** o **indicadores**, para poder tomar decisiones respecto a las estrategias del uso en cada uno de los recursos de la comunidad.
+* El consejo se divide como **seguidores de los grupos del Core Team**, de la siguiente manera:
+> * Gaby - Repositorio (Github, Sitio Web)
+> * Dafne - Redes Sociales (Facebook, Twitter, Meetup, Slack)
+> * David Flores - Financiamiento (Paetron, Administración)
+> * Mariano Renteria - Meetups
+> * David León - Proyectos (Mentorías, Slack-bot)
+
+## Elementos de acción
+
+* Revisar, leer y dedicar tiempo a la comprensión del documento del Governance: https://github.com/phpmx/comunidad/blob/main/Governance.md
+* Preguntar con cada miembro de los grupos del Core Team, las metas que deberíamos fijar a 6 meses, y quizás a 1 año.
+* Preguntar con cada miembro de los grupos del Core Team, iniciativas de actividades o proyectos nuevos a incluir en la comunidad.
+
+## Agenda de la próxima reunión
+
+Presentar las metas propuestas del Core Team, las iniciativas recibidas, y confirmar que cada miembro del consejo ha leído el documento del Governance. De esta forma, se puedan definir las metas que debemos cumplir como comunidad, al cabo de 6 meses, y de preferencia, también en 1 año.
+
+La siguiente reunión aún no tiene un día definido, pero será dentro de 15 días después de esta primera reunión, propuesta en el mismo horario, 8pm.
+

--- a/Consejo_2021/Minutas/2021-01-12.md
+++ b/Consejo_2021/Minutas/2021-01-12.md
@@ -1,0 +1,58 @@
+# Junta de Consejo Directivo
+
+12 DE ENERO DE 2021 / 21:00 HRS  / Google Meet
+
+## Asistentes 
+
+Dafne, Gaby, David Leon, Mariano Renteria
+
+## Agenda
+
+**Puntos pendientes de la reunión anterior**
+* Presentar las metas propuestas del Core Team.
+* Confirmar que cada miembro del consejo ha leído el documento de Governance: https://github.com/phpmx/comunidad/blob/main/Governance.md
+* Definir de manera genera las metas principales a 6 meses y quizás a 1 año.
+
+## Notas
+
+**Mariano Renteria**
+* Crear la Meetup 2.0 enfocada al esfuerzo del 2021.
+* Mejorar el formato de la meetup, con mayor interacción o dinámicas.
+
+**Dafne**
+* No hubo tiempo para definir metas.
+* Se propone tener mejores canales para que lleguen los mensajes de la comunidad a las personas indicadas, para ser publicadas en las redes.
+* También se propone contar con un listado de los miembros del Core Team, para compartir contenido de ellos en las redes sociales, y
+exista movimiento en las redes, fuera de los días de meetup, que suelen ser los días más activos.
+
+**Gaby**
+* Revisar el repositorio de Github, para prestar atención a los proyectos activos, y archivos aquellos que ya no son necesarios.
+* Cambiar el canal de slack para Github, y separarlo de community, para que se le pueda dar más atención al repositorio.
+* Revisar privilegios y usuarios activos en phpmx.
+* Se sugiere crear un canal en slack solo para los miembros del Core Team y tener comunicación más directa con todos.
+* Definir las etiquetas estándar de Github, para los repositorios y compartirlos con el equipo para promoveer un correcto uso de estos.
+* Promover dinámicas para poder regalar "swag", existen elefantitos y playeras que se pueden ocupar.
+* Mencionar en las meetup, los proyectos o formas de colaborar en el repositorio de phpmx.
+* Crear talleres o infografías dedicadas a ciertas herramientras, técnicas, tecnologías, etc. para hacer crecer la comunidad.
+
+**David Leon**
+* Definir documentación, enlaces y guías enfocadas al ciclo de vida de desarrollo web.
+* Construir una lista de mentores, para que en el canal de slack mentoring se puedan inscribir personas interesadas en ser "mentees".
+* Hacer la mentoría a los "mentees" para consutrir sistemas web enfocados a PHP o Python, principalmente, pero no es restrictivo.
+* Dar preferencia a TDD para contextualizar la documentación y guías del ciclo de vida.
+* A largo plazo, definir el despliegue de aplicaciones web por medio de la nube, para los proyectos desarrollados por los "mentees".
+
+## Elementos de acción
+
+* Revisar, leer y dedicar tiempo a la comprensión del documento del Governance: https://github.com/phpmx/comunidad/blob/main/Governance.md
+* Definir y acotar la redacción de las notas mencionadas en esta minuta, para confirmar las metas del 2021.
+* Publicar las metas del 2021, por equipos del Core Team.
+
+## Agenda de la próxima reunión
+
+David Flores falta exponer sus notas sobre los recursos financieros de la comunidad, se tiene que tratar en la siguiente reunión, para
+considerar más tiempo, y dialogar sobre los objetivos de estos recursos.
+
+La siguiente reunión aún no tiene un día definido, pero será dentro de 1 semanas después de esta segunda reunión, propuesta para un horario
+más nocturno, 10pm probablemente.
+

--- a/Consejo_2021/Minutas/2021-01-12.md
+++ b/Consejo_2021/Minutas/2021-01-12.md
@@ -21,19 +21,26 @@ Dafne, Gaby, David Leon, Mariano Renteria
 
 **Dafne**
 * No hubo tiempo para definir metas.
+* Se dio acceso a las cuentas de las redes sociales a los miembros del CoreTeam
 * Se propone tener mejores canales para que lleguen los mensajes de la comunidad a las personas indicadas, para ser publicadas en las redes.
-* También se propone contar con un listado de los miembros del Core Team, para compartir contenido de ellos en las redes sociales, y
-exista movimiento en las redes, fuera de los días de meetup, que suelen ser los días más activos.
+* Se propuso en la junta impulsar las iniciativas de los miembros de php (si tienen podcast, contenido, empleo?)
+* Se acordo que se tendrá otra reunión para redefinir las metas que deberíamos tener en redes sociales ya que no se habían planteado antes.
 
 **Gaby**
-* Revisar el repositorio de Github, para prestar atención a los proyectos activos, y archivos aquellos que ya no son necesarios.
-* Cambiar el canal de slack para Github, y separarlo de community, para que se le pueda dar más atención al repositorio.
-* Revisar privilegios y usuarios activos en phpmx.
+* Confirmar proyectos activos de github y archivar los que no están en uso (Javier)
+* Vincular las Notificaciones a un canal dedicado como Monitor del sitio y pull request (Erick)
+* Agregar descripción en el nuevo canal de slack
+* Confirmar usuarios activos/inactivos en phpmx para el repositorio (Javier)
+* Asignar los privilegios necesarios para los miembros del comité de github (Miguel)
 * Se sugiere crear un canal en slack solo para los miembros del Core Team y tener comunicación más directa con todos.
 * Definir las etiquetas estándar de Github, para los repositorios y compartirlos con el equipo para promoveer un correcto uso de estos.
 * Promover dinámicas para poder regalar "swag", existen elefantitos y playeras que se pueden ocupar.
-* Mencionar en las meetup, los proyectos o formas de colaborar en el repositorio de phpmx.
-* Crear talleres o infografías dedicadas a ciertas herramientras, técnicas, tecnologías, etc. para hacer crecer la comunidad.
+* Mencionar en las meetups qué issues hay y los canales adecuados. 
+* Infografías de cómo hacer fork, commit, etc.? Para que "No saber usar github" no sea un obstáculo
+* Ayudar a Erick con las tareas del bot. Tiene confirmado apoyo de Alex, Ricardo y Vicente. pero ver cómo le podemos conseguir más personas.
+* Comunicar tips para no trabajar 2 personas en el mismo issue (Ref. situación Miguel y Fidel). Puede ser asignar a la persona y quitar el help wanted, pero comunicar eso.
+* Recomendación para el Team de Patreon: https://opencollective.com/
+
 
 **David Leon**
 * Definir documentación, enlaces y guías enfocadas al ciclo de vida de desarrollo web.
@@ -55,4 +62,3 @@ considerar más tiempo, y dialogar sobre los objetivos de estos recursos.
 
 La siguiente reunión aún no tiene un día definido, pero será dentro de 1 semanas después de esta segunda reunión, propuesta para un horario
 más nocturno, 10pm probablemente.
-

--- a/Miembros.md
+++ b/Miembros.md
@@ -1,7 +1,7 @@
 
 # Miembros de la Comunidad PHP México
 
-Todos son **¡Bienvenidos!** a la comunidad de [PHP México](https://phpmexico.mx/), y todos pueden formar parte de uno o varios medios de interacción con los que cuenta la comunidad. Pero existen ciertos miembros, que se destacan por su participación, donación o acciones dentro de la comunidad, para mejorar o mantener los proyectos que llevamos a cabo; así que se dividen según estos medios o recursos o proyectos, a continuación los miembros destacados de la comunidad.
+Todas las personas son **¡Bienvenidas!** a formar parte de la comunidad de [PHP México](https://phpmexico.mx/) y participar cualquiera de los medios de interacción con los que contamos, pero existen algunas que se destacan por su participación, donación o acciones dentro de la comunidad, para mejorar o mantener los proyectos que llevamos a cabo; así que se dividen según estos medios, recursos o proyectos. A continuación se encuentra la lista de dichas personas y su diferente organización.
 
 ## Consejo Directivo Anual
 

--- a/Miembros.md
+++ b/Miembros.md
@@ -19,6 +19,8 @@ Las personas que integran el Consejo Directivo Anual, se renuevan cada año, por
 
 * Mariano (marianorenteria)
 
+Votación: https://civs.cs.cornell.edu/cgi-bin/results.pl?id=E_64b6e9d001ebe552
+
 ## Core Team
 
 Las personas que integran el Core Team tienen distintos tiempos de duración con sus responsabilidades, según sea cada una de estas; y se enfocan en gestionar o mantener un aspecto o recurso, colaborando en un esfuerzo coordinado para cumplir con los proyectos de la comunidad.

--- a/Miembros.md
+++ b/Miembros.md
@@ -1,0 +1,112 @@
+
+# Miembros de la Comunidad PHP México
+
+Todos son **¡Bienvenidos!** a la comunidad de [PHP México](https://phpmexico.mx/), y todos pueden formar parte de uno o varios medios de interacción con los que cuenta la comunidad. Pero existen ciertos miembros, que se destacan por su participación, donación o acciones dentro de la comunidad, para mejorar o mantener los proyectos que llevamos a cabo; así que se dividen según estos medios o recursos o proyectos, a continuación los miembros destacados de la comunidad.
+
+## Consejo Directivo Anual
+
+Los miembros del Consejo Directivo Anual, se renuevan cada año, por votos de la comunidad; y su principal atribución es contar con autoridad amplia de toma de decisiones acerca del rumbo de la comunidad y sus proyectos.
+
+### 2021
+
+* -en proceso de votación-
+
+## Core Team
+
+Los miembros del Core Team tienen distintos tiempos de duración con sus responsabilidades, según sea cada una de estas; y se enfocan en gestionar o mantener un aspecto o recurso, colaborando en un esfuerzo coordinado para cumplir con los proyectos de la comunidad.
+
+NOTA*. Entre paréntesis se anota el alias del usuario en [Slack](https://phpmx.slack.com/).
+
+### Redes Sociales: Facebook
+
+* David (gnuget)
+
+* Carlos (jcarlos)
+
+* Aldo (aldo.xyz)
+
+* Asfo (asfo)
+
+### Redes Sociales: Twitter
+
+* Mariano (marianorenteria)
+
+* Luis (lcortes)
+
+* Dafne (Daffyta)
+
+* Victor (TheKingOfBongo)
+
+### Redes Sociales: Meetup
+
+* Dafne (Daffyta)
+
+* Juan (jujo)
+
+### Financiamiento: Paetron
+
+* David (dmouse)
+
+### Financiamiento: Administración
+
+* Fidel (jashk)
+
+* Juan (jujo)
+
+* Jesus (jmolivas)
+
+### Proyectos: Mentoring
+
+* Aldo (roboninja)
+
+* David (jelidleon)
+
+* Asfo (asfo)
+
+### Proyectos: Slack-Bot
+
+* Erick (Erick)
+
+* Ricardo (ricardorivera)
+
+### Repositorio: Github
+
+* Erick (Erick)
+
+* Ricardo (ricardorivera)
+
+* Miguel (gueroverde)
+
+* Javier (javierledezma)
+
+### Sitio Web
+
+* Erick (Erick)
+
+* Ricardo (ricardorivera)
+
+* Alex (alexvargas)
+
+* Miguel (gueroverde)
+
+### Slack
+
+* Mariano (marianorenteria)
+
+* Juan (jujo)
+
+* Erick (Erick)
+
+* David (gnuget)
+
+### Meetup (organización, elaboración, difusión)
+
+* Mariano (marianorenteria)
+
+* Gaby (gabygaby)
+
+* Fidel (jashk)
+
+* Marco (rzerostern)
+
+* Sagrario (smmd)

--- a/Miembros.md
+++ b/Miembros.md
@@ -5,7 +5,7 @@ Todas las personas son **¡Bienvenidas!** a formar parte de la comunidad de [PHP
 
 ## Consejo Directivo Anual
 
-Los miembros del Consejo Directivo Anual, se renuevan cada año, por votos de la comunidad; y su principal atribución es contar con autoridad amplia de toma de decisiones acerca del rumbo de la comunidad y sus proyectos.
+Las personas que integran el Consejo Directivo Anual, se renuevan cada año, por votos de la comunidad; y su principal atribución es contar con autoridad amplia de toma de decisiones acerca del rumbo de la comunidad y sus proyectos.
 
 ### 2021
 

--- a/Miembros.md
+++ b/Miembros.md
@@ -9,7 +9,15 @@ Las personas que integran el Consejo Directivo Anual, se renuevan cada año, por
 
 ### 2021
 
-* -en proceso de votación-
+* Gaby (gabygaby)
+
+* Dafne (Daffyta)
+
+* David (dmouse)
+
+* David (jelid.leon)
+
+* Mariano (marianorenteria)
 
 ## Core Team
 

--- a/Miembros.md
+++ b/Miembros.md
@@ -13,7 +13,7 @@ Las personas que integran el Consejo Directivo Anual, se renuevan cada año, por
 
 ## Core Team
 
-Los miembros del Core Team tienen distintos tiempos de duración con sus responsabilidades, según sea cada una de estas; y se enfocan en gestionar o mantener un aspecto o recurso, colaborando en un esfuerzo coordinado para cumplir con los proyectos de la comunidad.
+Las personas que integran el Core Team tienen distintos tiempos de duración con sus responsabilidades, según sea cada una de estas; y se enfocan en gestionar o mantener un aspecto o recurso, colaborando en un esfuerzo coordinado para cumplir con los proyectos de la comunidad.
 
 NOTA*. Entre paréntesis se anota el alias del usuario en [Slack](https://phpmx.slack.com/).
 


### PR DESCRIPTION
- Primera minuta del consejo 2021, con fecha del 28/Dic
- Segunda minuta del consejo, con fecha del 12/Ene
- Estructura para las metas del 2021